### PR TITLE
Removed rabbit vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,6 @@ Role Variables
 | `console_token_ttl` | `600` | How many seconds before deleting tokens ||
 | `consoleauth_manager` | `nova.consoleauth.manager.ConsoleAuthManager` | Manager for console auth ||
 
-
-### RabbitMQ (must exist)
-
-| Name | Default value | Description | Note |
-|---  |---  |---  |--- |
-| `rabbit_hostname` | `localhost` | Hostname/IP address where the RabbitMQ service runs ||
-| `rabbit_username` | `rabbit_username_default` | RabbitMQ username for glance ||
-| `rabbit_pass` | `rabbit_pass_default` | RabbitMQ password for glance. ||
-
-
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,8 +24,3 @@ consoleauth_manager: nova.consoleauth.manager.ConsoleAuthManager
 
 # Common
 my_ip: "{{ ansible_eth0.ipv4.address }}"
-
-# RabbitMQ
-rabbit_hostname: localhost
-rabbit_pass: rabbit_pass_default
-rabbit_username: rabbit_username_default


### PR DESCRIPTION
Rabbit vars are not referenced anywhere in this role.  Adds
to confusion when configuring.
