### PR TITLE
Added memcached_servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Role Variables
 | `console_token_ttl` | `600` | How many seconds before deleting tokens ||
 | `consoleauth_manager` | `nova.consoleauth.manager.ConsoleAuthManager` | Manager for console auth ||
 
-
 ### RabbitMQ (must exist)
 
 | Name | Default value | Description | Note |
@@ -32,6 +31,11 @@ Role Variables
 | `rabbit_username` | `rabbit_username_default` | RabbitMQ username for glance ||
 | `rabbit_pass` | `rabbit_pass_default` | RabbitMQ password for glance. ||
 
+### Memcached
+
+| Name | Default value | Description | Note |
+|---  |---  |---  |--- |
+| `memcached_servers` | `None` | A comma delimited string of hostname:port combos where the Memcached service runs ||
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,6 @@ my_ip: "{{ ansible_eth0.ipv4.address }}"
 rabbit_hostname: localhost
 rabbit_pass: rabbit_pass_default
 rabbit_username: rabbit_username_default
+
+# Memcached
+memcached_servers: None

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -37,5 +37,9 @@
     - section:  DEFAULT
       option:   consoleauth_manager
       value:    "{{ consoleauth_manager }}"
+    # Memcached
+    - section:  DEFAULT
+      option:   memcached_servers
+      value:    "{{ memcached_servers }}"
   notify:
     - Restart nova consoleauth


### PR DESCRIPTION
This provides HA to console auth.  If memcached_servers is defined,
tokens are stored in memcached, so all consoleauth processes
have access to authenticated clients.
