### PR TITLE
Consoleauth requires database access

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,9 @@ nova_consoleauth_public_hostname: localhost
 nova_consoleauth_token_ttl: 600
 nova_consoleauth_manager: nova.consoleauth.manager.ConsoleAuthManager
 
+# Database
+nova_consoleauth_database_url: sqlite:////var/lib/nova/nova.db
+
 # Common
 my_ip: "{{ ansible_eth0.ipv4.address }}"
 

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -43,3 +43,16 @@
       value:    "{{ nova_consoleauth_memcached_servers }}"
   notify:
     - Restart nova consoleauth
+
+- name: Configure nova consoleauth database
+  ini_file: >
+    dest=/etc/nova/nova.conf
+    section="{{ item.section }}"
+    option="{{ item.option }}"
+    value="{{ item.value }}"
+  with_items:
+    - section: database
+      option: connection
+      value: "{{ nova_consoleauth_database_url }}"
+  notify:
+    - Restart nova consoleauth


### PR DESCRIPTION
This service needs a database configured to work properly.  This patch
is a work in progress to remove the dependency on running co-located
with a service that wrote out a proper nova.conf. #9
